### PR TITLE
Clear up baucis dependency - Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,10 @@
   "license": "MIT",
   "dependencies": {
     "deco": "~0.10.2",
-    "baucis": "^0.20.5"
   },
   "peerDependencies": {
     "mongoose": "~3.8.8",
-    "baucis": ">=0.20.0"
+    "baucis": "^0.20.5"
   },
   "devDependencies": {
     "mocha": "~1.8.2",
@@ -42,7 +41,7 @@
     "request": "~2.21.0",
     "mongoose": "~3.8.8",
     "express": "~3.5.1",
-    "baucis": ">=0.20.0",
+    "baucis": "^0.20.5",
     "async": "~0.2.9"
   },
   "keywords": [


### PR DESCRIPTION
There seems to be a redundancy about the baucis dependency declaration. I end up with two baucis subfolders in my node_modules, one explicit, one in baucis-swagger. Using only the peer dependency solves the problem.
Furthermore, there is a discrepancy about the dependency version. I updated it with the upper.