### PR TITLE
prevent crash on Mixed type due to logging bug

### DIFF
--- a/Controller.js
+++ b/Controller.js
@@ -80,7 +80,7 @@ var decorator = module.exports = function () {
 
     if (!property.type) {
       console.log('Warning: That field type is not yet supported in baucis Swagger definitions, using "string."');
-      console.log('Path name: %s.%s', definition.id, name);
+      console.log('Path name: %s.%s', controller.model().plural(), name);
       console.log('Mongoose type: %s', path.options.type);
       property.type = 'string';
     }


### PR DESCRIPTION
Controller.js was trying to log `definition.id` which did not exist in that given scope. Changed it to `controller.model().plural()` as I believe that is what was intended.

Without this fix, things like [swagger-ui](https://github.com/swagger-api/swagger-ui) cannot work.